### PR TITLE
Install instructions tidy up environment names

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -61,26 +61,26 @@ Installation environment
       ``ubermag`` via ``pip``. You have to manually install Python and pip for
       your operating system.
 
-      First, we create a new virtual environment, here called ``ubermag_dev``.
-      To use a different name, replace ``ubermag_dev`` with your desired name. A
+      First, we create a new virtual environment, here called ``ubermag_venv``.
+      To use a different name, replace ``ubermag_venv`` with your desired name. A
       new folder with the given environment name will be created in the current
       directory.
 
       .. code-block::
 
-         $ python3 -m venv ubermag_env
+         $ python3 -m venv ubermag_venv
 
       To activate the environment on Windows, run:
 
       .. code-block::
 
-         $ ubermag_env\Scripts\activate.bat
+         $ ubermag_venv\Scripts\activate.bat
 
       On Linux or MacOS, run:
 
       .. code-block::
 
-         $ source ubermag_env/bin/activate
+         $ source ubermag_venv/bin/activate
 
 Installation
 ------------

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -46,13 +46,13 @@ Installation environment
       (Windows), create a new environment and activate it.
 
       Here, we show how to create and activate a new conda environment called
-      ``ubermag_dev``. To use a different name, replace ``ubermag_dev`` with
+      ``ubermag_env``. To use a different name, replace ``ubermag_env`` with
       your desired name.
 
       .. code-block::
 
          $ conda create -n ubermag_env python=3.8
-         $ conda activate ubermag
+         $ conda activate ubermag_env
 
    .. tab-item:: pip + venv
       :sync: pip_install


### PR DESCRIPTION
- use `_env` consistently for ubermag install

- use `_venv` consistently for pip install

  1. first use the same name for the virtual environment (was just broken before)

  2. use `_venv` as the extension for the Virtual ENVironment, to show that this is different from the conda-based environment (which we called `_env`).